### PR TITLE
AIESEC-86 Full Text Search in CollegeCourse and University endpoints

### DIFF
--- a/app/controllers/college_courses_controller.rb
+++ b/app/controllers/college_courses_controller.rb
@@ -1,7 +1,7 @@
 class CollegeCoursesController < ApplicationController
-  expose :college_courses, -> { CollegeCourse.all }
+  expose :college_courses, -> { CollegeCourse.by_name(params[:name]) }
 
   def index
-    render json: college_courses.as_json
+    render json: college_courses.as_json(only: [:id, :name])
   end
 end

--- a/app/controllers/universities_controller.rb
+++ b/app/controllers/universities_controller.rb
@@ -1,7 +1,7 @@
 class UniversitiesController < ApplicationController
-  expose :universities, -> { University.all }
+  expose :universities, -> { University.by_name(params[:name]) }
 
   def index
-    render json: universities.as_json
+    render json: universities.as_json(only: [:id, :name])
   end
 end

--- a/app/models/college_course.rb
+++ b/app/models/college_course.rb
@@ -1,13 +1,8 @@
 class CollegeCourse < ApplicationRecord
-  has_many :exchange_participants
-
-  ##
-  # :singleton-method:
-  # Returns all College Courses which contains in its name the given string 
-  # (case-insensitive)
-  # Will otherwise return all College Courses if no param is given, due to
-  # LIKE's wildcard % (zero, one or multiple characters)
   scope :by_name, -> (name = nil) { where("lower(name) LIKE ?", "%#{name}%") } 
 
-  validates_presence_of :name, :podio_id
+  has_many :exchange_participants
+
+  validates :podio_id, presence: true
+  validates :name, presence: true
 end

--- a/app/models/college_course.rb
+++ b/app/models/college_course.rb
@@ -1,13 +1,13 @@
 class CollegeCourse < ApplicationRecord
-  validates_presence_of :name, :podio_id
-
   has_many :exchange_participants
 
-  def as_json
-    {
-      id: id,
-      name: name,
-      podio_id: podio_id
-    }
-  end
+  ##
+  # :singleton-method:
+  # Returns all College Courses which contains in its name the given string 
+  # (case-insensitive)
+  # Will otherwise return all College Courses if no param is given, due to
+  # LIKE's wildcard % (zero, one or multiple characters)
+  scope :by_name, -> (name = nil) { where("lower(name) LIKE ?", "%#{name}%") } 
+
+  validates_presence_of :name, :podio_id
 end

--- a/app/models/university.rb
+++ b/app/models/university.rb
@@ -1,13 +1,8 @@
 class University < ApplicationRecord
-  has_many :exchange_participants
-  
-  ##
-  # :singleton-method:
-  # Returns all Universities which contains in its name the given string 
-  # (case-insensitive)
-  # Will otherwise return all Universities if no param is given, due to
-  # LIKE's wildcard % (zero, one or multiple characters)
   scope :by_name, -> (name = nil) { where("lower(name) LIKE ?", "%#{name}%") } 
+  
+  has_many :exchange_participants
 
-  validates_presence_of :name, :podio_id
+  validates :podio_id, presence: true
+  validates :name, presence: true
 end

--- a/app/models/university.rb
+++ b/app/models/university.rb
@@ -1,13 +1,13 @@
 class University < ApplicationRecord
-  validates_presence_of :name, :podio_id
-
   has_many :exchange_participants
+  
+  ##
+  # :singleton-method:
+  # Returns all Universities which contains in its name the given string 
+  # (case-insensitive)
+  # Will otherwise return all Universities if no param is given, due to
+  # LIKE's wildcard % (zero, one or multiple characters)
+  scope :by_name, -> (name = nil) { where("lower(name) LIKE ?", "%#{name}%") } 
 
-  def as_json
-    {
-      id: id,
-      name: name,
-      podio_id: podio_id
-    }
-  end
+  validates_presence_of :name, :podio_id
 end

--- a/spec/controllers/college_courses_controller_spec.rb
+++ b/spec/controllers/college_courses_controller_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe CollegeCoursesController, type: :controller do
   describe "#index" do
-    subject(:do_index) { get :index }
     let(:response) { JSON.parse(subject.body) }
+ 
+    subject(:do_index) { get :index }
 
     it { is_expected.to be_successful }
 
@@ -14,8 +15,27 @@ RSpec.describe CollegeCoursesController, type: :controller do
 
       context "filled list" do
         before { create_list(:college_course, 3) }
-        it { expect(response.first.keys).to match_array(['id', 'name', 'podio_id']) }
-        it { expect(response.count).to eq CollegeCourse.count }
+        
+        context 'format' do
+          it { expect(response.first.keys).to match_array(['id', 'name']) }
+        end
+
+        context 'with no params' do
+          it { expect(response).to match_array(CollegeCourse.all.as_json(only: [:id, :name])) }
+
+          it { expect(response.count).to eq CollegeCourse.count }
+        end
+
+        context 'with name param' do
+          subject(:do_index) { get :index, params: { name: 'abc' } }
+
+          let!(:first_college_course) { create(:college_course, name: 'Bachelor in ABC') }
+          let!(:second_college_course) { create(:college_course, name: 'Abc Master\'s Degree') }
+
+          it { expect(response).to match_array([first_college_course, second_college_course].as_json(only: [:id, :name])) }
+
+          it { expect(response.count).to eq([first_college_course, second_college_course].count) }
+        end
       end
     end
   end

--- a/spec/controllers/universities_controller_spec.rb
+++ b/spec/controllers/universities_controller_spec.rb
@@ -1,21 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe UniversitiesController, type: :controller do
-  describe "#index" do
-    subject(:do_index) { get :index }
+  describe '#index' do
     let(:response) { JSON.parse(subject.body) }
+    
+    subject(:do_index) { get :index }
 
     it { is_expected.to be_successful }
 
-    describe "response" do
-      context "empty list" do
+    describe 'response' do
+      context 'empty list' do
         it { expect(response).to be_empty }
       end
 
-      context "filled list" do
+      context 'filled list' do
         before { create_list(:university, 3) }
-        it { expect(response.first.keys).to match_array(['id', 'name', 'podio_id']) }
-        it { expect(response.count).to eq University.count }
+
+        context 'format' do
+
+          it { expect(response.first.keys).to match_array(['id', 'name']) }
+        end
+
+        context 'with no params' do  
+          it { expect(response).to match_array(University.all.as_json(only: [:id, :name])) }
+
+          it { expect(response.count).to eq University.count }
+        end
+
+        context 'with name param' do
+          subject(:do_index) { get :index, params: { name: 'abc' } }
+
+          let!(:first_university) { create(:university, name: 'ABC University') }
+          let!(:second_university) { create(:university, name: 'University of abc') }
+
+          it { expect(response).to eq([first_university, second_university].as_json(only: [:id, :name])) }
+
+          it { expect(response.count).to eq([first_university, second_university].count) }
+
+        end
       end
     end
   end

--- a/spec/controllers/universities_controller_spec.rb
+++ b/spec/controllers/universities_controller_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe UniversitiesController, type: :controller do
         before { create_list(:university, 3) }
 
         context 'format' do
-
           it { expect(response.first.keys).to match_array(['id', 'name']) }
         end
 
@@ -36,7 +35,6 @@ RSpec.describe UniversitiesController, type: :controller do
           it { expect(response).to eq([first_university, second_university].as_json(only: [:id, :name])) }
 
           it { expect(response.count).to eq([first_university, second_university].count) }
-
         end
       end
     end

--- a/spec/models/college_course_spec.rb
+++ b/spec/models/college_course_spec.rb
@@ -1,6 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe CollegeCourse, type: :model do
+  describe "#associations" do
+    it { is_expected.to have_many :exchange_participants }
+  end
+
+  describe '#scopes' do
+    context 'by_name' do
+      let!(:college_course) { create(:college_course, name: 'Bachelor By Name Scope') }
+
+      let!(:college_courses) { create_list(:college_course, 3) }
+
+      context 'with no given param' do
+        it { expect(CollegeCourse.by_name).to match_array(CollegeCourse.all) }
+        it { expect(CollegeCourse.by_name.count). to eq CollegeCourse.count }
+      end
+
+      context 'with given param' do
+        it { expect(CollegeCourse.by_name('by name')).to match_array([college_course]) }
+
+        it { expect(CollegeCourse.by_name('by name').count).to eq 1 }
+      end
+    end
+  end
+
   describe "#attributes" do
     it { is_expected.to respond_to :name }
     it { is_expected.to respond_to :podio_id }
@@ -9,9 +32,5 @@ RSpec.describe CollegeCourse, type: :model do
   describe "#validations" do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_presence_of :podio_id }
-  end
-
-  describe "#associations" do
-    it { is_expected.to have_many :exchange_participants }
   end
 end

--- a/spec/models/college_course_spec.rb
+++ b/spec/models/college_course_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CollegeCourse, type: :model do
   end
 
   describe '#scopes' do
-    context 'by_name' do
+    describe 'by_name' do
       let!(:college_course) { create(:college_course, name: 'Bachelor By Name Scope') }
 
       let!(:college_courses) { create_list(:college_course, 3) }

--- a/spec/models/university_spec.rb
+++ b/spec/models/university_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe University, type: :model do
   end
 
   describe '#scopes' do
-    context 'by_name' do
+    describe 'by_name' do
       let!(:university) { create(:university, name: 'University By Name Scope') }
       
       let!(:universities) { create_list(:university, 3) }

--- a/spec/models/university_spec.rb
+++ b/spec/models/university_spec.rb
@@ -1,6 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe University, type: :model do
+  describe "#associations" do
+    it { is_expected.to have_many :exchange_participants }
+  end
+
+  describe '#scopes' do
+    context 'by_name' do
+      let!(:university) { create(:university, name: 'University By Name Scope') }
+      
+      let!(:universities) { create_list(:university, 3) }
+      
+      context 'with no given param' do
+        it { expect(University.by_name).to match_array(University.all) }
+        it { expect(University.by_name.count).to eq University.count }
+      end
+
+      context 'with given param' do
+        it { expect(University.by_name('by name')).to match_array([university]) }
+        it { expect(University.by_name('by name').count).to eq 1 }
+      end
+    end
+  end
+
   describe "#attributes" do
     it { is_expected.to respond_to :name }
     it { is_expected.to respond_to :podio_id }
@@ -11,7 +33,4 @@ RSpec.describe University, type: :model do
     it { is_expected.to validate_presence_of :podio_id }
   end
 
-  describe "#associations" do
-    it { is_expected.to have_many :exchange_participants }
-  end
 end


### PR DESCRIPTION
Para CollegeCourse e University:
- adicionado escopo `by_name` para filtrar os registros por nome (retornando todos quando o parâmetro é nulo)
- formatação da resposta JSON para retornar apenas _id_ e nome