### PR TITLE
Log errors from expa application sync into slack.

### DIFF
--- a/app/repos/chat_logger.rb
+++ b/app/repos/chat_logger.rb
@@ -1,6 +1,7 @@
 require 'slack-notifier'
 
 module Repos
+  # Responsible for log errors on Work Chat Ex: Slack
   class ChatLogger
     def self.notify_on_client_channel(message)
       notifier = Slack::Notifier.new ENV['SLACK_WEBHOOK_URL'] do

--- a/app/repos/chat_logger.rb
+++ b/app/repos/chat_logger.rb
@@ -1,0 +1,14 @@
+require 'slack-notifier'
+
+module Repos
+  class ChatLogger
+    def self.notify_on_client_channel(message)
+      notifier = Slack::Notifier.new ENV['SLACK_WEBHOOK_URL'] do
+        defaults channel: "##{ENV['SLACK_CLIENT_CHANNEL']}",
+                 username: "notifier"
+      end
+
+      notifier.ping(message)
+    end
+  end
+end

--- a/app/services/expa_application_sync.rb
+++ b/app/services/expa_application_sync.rb
@@ -1,4 +1,5 @@
 require "#{Rails.root}/lib/expa_api"
+require "#{Rails.root}/app/repos/chat_logger"
 
 class ExpaApplicationSync
   def self.call(logger=nil)
@@ -34,6 +35,11 @@ class ExpaApplicationSync
       log += " last status #{application.status}"
       log += " application id #{application.id}"
       logger.info log
+    rescue StandardError => error
+      logger.error error.message
+      message = "Error when trying sync ogx applications: #{error.message}"
+      Repos::ChatLogger.notify_on_client_channel(message)
+      raise
     end
   end
 

--- a/app/services/expa_application_sync.rb
+++ b/app/services/expa_application_sync.rb
@@ -36,8 +36,8 @@ class ExpaApplicationSync
       log += " application id #{application.id}"
       logger.info log
     rescue StandardError => error
-      logger.error error.message
       message = "Error when trying sync ogx applications: #{error.message}"
+      logger.error message
       Repos::ChatLogger.notify_on_client_channel(message)
       raise
     end


### PR DESCRIPTION
With this, we could quickly fix problems with sync.

* Need configure var ENV SLACK_CLIENT_CHANNEL