### PR TITLE
feat(repository_podio/repository_application): now matched status fro…

### DIFF
--- a/app/repos/repository_application.rb
+++ b/app/repos/repository_application.rb
@@ -33,13 +33,12 @@ class RepositoryApplication
   def self.pending_podio_sync_icx_applications
     Expa::Application
       .where('exchange_participant_id is not null')
-      .where.not(status: %i[matched approved_tn_manager approved_ep_manager]) #this statuses should be ignored in this context
+      .where.not(status: %i[approved_tn_manager approved_ep_manager]) #this statuses should be ignored in this context
       .joins(:exchange_participant)
       .where(exchange_participants: { exchange_type: :icx })
       .where(podio_last_sync: nil)
       .where(has_error: false)
       .order('updated_at_expa': :desc)
-      .limit 10
   end
 
   private

--- a/app/repos/repository_application.rb
+++ b/app/repos/repository_application.rb
@@ -39,6 +39,7 @@ class RepositoryApplication
       .where(podio_last_sync: nil)
       .where(has_error: false)
       .order('updated_at_expa': :desc)
+      limit(10)
   end
 
   private

--- a/app/repos/repository_podio.rb
+++ b/app/repos/repository_podio.rb
@@ -287,11 +287,12 @@ class RepositoryPodio
       }
       mapper[status]
     end
-
+    
     def icx_status_to_podio(status)
       mapping = {
         open: 1,
         applied: 1,
+        matched: 8,
         accepted: 2,
         approved: 3,
         realized: 3, #this status is after 'approved' and it'll only be be used in ICX PREP, in this stage it must stop on 'approved' status


### PR DESCRIPTION
…m expa is mapped to Podio