### PR TITLE
feat(expa_sign_up): Implements new strategy for EP Sign Ups

### DIFF
--- a/app/services/expa_sign_up.rb
+++ b/app/services/expa_sign_up.rb
@@ -1,5 +1,3 @@
-require 'slack-notifier'
-require 'concerns/check_person_present'
 require 'open-uri'
 
 class ExpaSignUp
@@ -7,84 +5,49 @@ class ExpaSignUp
     new(params).call
   end
 
+  attr_accessor :res
   attr_reader :exchange_participant, :status
 
   def initialize(params)
-    @status = false
     @exchange_participant = ExchangeParticipant.find_by(
       id: params['exchange_participant_id']
     )
   end
 
   def call
-    send_data_to_expa(@exchange_participant)
+    @res = sign_up_user
+    update_exchange_participant_id if @res.code == 201
 
-    notify_slack("Error synching EP:\n#{@exchange_participant.fullname} - #{@exchange_participant.email} on ENV: #{ENV['ENV']}") unless @status
-
-    @status
+    @res
   end
 
   private
 
-  def notify_slack(message)
-    notifier = Slack::Notifier.new ENV['SLACK_WEBHOOK_URL'] do
-      defaults channel: "##{ENV['SLACK_CHANNEL']}",
-               username: "notifier"
-    end
-
-    notifier.ping(message)
-  end
-
-  def submit_data(exchange_participant)
-    HTTParty.post(
-      'https://auth.aiesec.org/users/',
-      body: {
-        'authenticity_token' => authenticity_token,
-        'utf8' => '✓',
-        'user[email]' => exchange_participant.email.downcase,
-        'user[first_name]' => exchange_participant.first_name,
-        'user[last_name]' => exchange_participant_last_name(exchange_participant.last_name),
-        'user[password]' => exchange_participant.decrypted_password,
-        'user[phone]' => exchange_participant.cellphone,
-        'user[country]' => ENV['EXPA_COUNTRY'],
-        'user[mc]' => ENV['EXPA_MC_ID'],
-        'user[lc]' => exchange_participant.local_committee.expa_id,
-        'user[lc_input]' => exchange_participant.local_committee.expa_id,
-        'user[allow_phone_communication]' =>
-          exchange_participant.cellphone_contactable
-      }
+  def sign_up_user
+    HTTParty.post(ENV['EXPA_SIGNUP_URL'],
+      body: payload,
+      headers: { 'Content-Type' => 'application/json' }
     )
   end
 
-  def exchange_participant_last_name(last_name)
-    unless last_name.empty?
-      last_name
-    else
-      '-'
-    end
+  def payload
+    {
+      user: {
+        first_name: @exchange_participant.first_name,
+        last_name: @exchange_participant.last_name,
+        email: @exchange_participant.email,
+        country_code: ENV['COUNTRY_CODE'],
+        phone: @exchange_participant.cellphone,
+        password: @exchange_participant.password,
+        lc: @exchange_participant.local_committee.expa_id,
+        mc: ENV['EXPA_MC_ID'],
+        allow_phone_communication: @exchange_participant.cellphone_contactable,
+        created_via: "json"
+      }
+    }.to_json
   end
 
-  def send_data_to_expa(exchange_participant)
-    submit_data(exchange_participant)
-
-    id = exchange_participant_expa_id(exchange_participant)
-    unless id.nil?
-      @status = true if exchange_participant.update_attributes(expa_id: id)
-    end
-  end
-
-  def exchange_participant_expa_id(exchange_participant)
-    EXPAAPI::Client.query(
-      ExistsQuery,
-      variables: { email: exchange_participant.email.downcase }
-    ).data&.check_person_present&.id
-  end
-
-  def authenticity_token
-    sign_up_page.css('.signup_op [name=authenticity_token]').first['value']
-  end
-
-  def sign_up_page
-    Nokogiri::HTML(open('https://auth.aiesec.org/users/sign_in'))
+  def update_exchange_participant_id
+    @exchange_participant.update_attribute(:expa_id, @res.parsed_response['person_id'])
   end
 end

--- a/app/workers/sign_up_worker.rb
+++ b/app/workers/sign_up_worker.rb
@@ -8,6 +8,6 @@ class SignUpWorker
                     body_parser: JSON
 
   def perform(sqs_msg, body)
-    sqs_msg.delete if ExpaSignUp.call(body)
+    sqs_msg.delete if ExpaSignUp.call(body).code == 201
   end
 end

--- a/spec/services/expa_sign_up_spec.rb
+++ b/spec/services/expa_sign_up_spec.rb
@@ -1,21 +1,46 @@
 require 'rails_helper'
 
-# RSpec.describe ExpaSignUp do
-#   subject { service }
-#
-#   let(:service) { described_class.new(params) }
-#
-#   let(:exchange_participant) do
-#     create(:exchange_participant,
-#            fullname: 'Forrest Gump',
-#            registerable: build(:gv_participant))
-#   end
-#
-#   let(:params) { { exchange_participant_id: exchange_participant.id } }
-#
-#   it { is_expected.to respond_to(:call) }
-#
-#   it { is_expected.to respond_to(:exchange_participant) }
-#
-#   it { is_expected.to respond_to(:status) }
-# end
+RSpec.describe ExpaSignUp do
+  ENV['EXPA_SIGNUP_URL'] = 'https://auth-staging.aiesec.org/users.json'
+
+  subject { service }
+
+  let(:service) { described_class.new(params) }
+
+  let(:local_committee_id) { create(:local_committee, expa_id: 1248).id }
+
+  let(:exchange_participant) do
+    create(:exchange_participant,
+           fullname: 'Forrest Gump',
+           email: Faker::Internet.email,
+           cellphone: '99999999999',
+           password: "Password123",
+           local_committee_id: local_committee_id,
+           cellphone_contactable: true,
+           expa_id: nil,
+           registerable: build(:gv_participant)
+          )
+  end
+
+  let(:params) { { exchange_participant_id: exchange_participant.id }.stringify_keys }
+
+  it { is_expected.to respond_to(:call) }
+
+  it { is_expected.to respond_to(:exchange_participant) }
+
+  it { is_expected.to respond_to(:status) }
+
+  describe 'success' do
+    it 'creates user' do
+      res = service.call
+      expect(res.code).to eq 201
+    end
+
+    it 'updates user expa_id' do
+      res = service.call
+
+      exchange_participant.reload
+      expect(exchange_participant.expa_id).to eq res.parsed_response['person_id']
+    end
+  end
+end


### PR DESCRIPTION
EPs are now signed up upon a HTTP POST (with a JSON payload) to the newly provided endpoint.
Environment variables:
EXPA_SIGNUP_URL: stores the endpoint, for production: https://auth.aiesec.org/users.json, and staging: https://auth-staging.aiesec.org/users.json
EXPA_MC_ID: the MC id on EXPA
COUNTRY_CODE: international dialing country code, e.g. '+55'

SQS messages will be deleted only upon a return status of 201 (created)

For more information, refer to the official documentation at https://docs.aiesec.org/display/EXPA/Sign+up+users+-+API