### PR TITLE
feat(podio_ogx_): implements PodioOgxStatusUpdate and adds general enhancements to existent codebase

### DIFF
--- a/app/repos/repository_podio.rb
+++ b/app/repos/repository_podio.rb
@@ -7,6 +7,11 @@ class RepositoryPodio
       Podio::Item.create(application, fields: params)
     end
 
+    def update_fields(id, params)
+      check_podio
+      Podio::Item.update(id, fields: params)
+    end
+
     def delete_ep(id)
       check_podio
       Podio::Item.delete(id)

--- a/app/services/brazil/podio_ogx_status_update.rb
+++ b/app/services/brazil/podio_ogx_status_update.rb
@@ -1,0 +1,44 @@
+module Brazil
+  class PodioOgxStatusUpdate
+
+    def self.call(params)
+      new(params).call
+    end
+
+    attr_reader :application
+    attr_accessor :status
+
+    def initialize(params)
+      @application = params
+      @status = false
+    end
+
+    def call
+      res = update_application_on_podio
+
+      @status = update_application_locally if res == 200
+
+      @status
+    end
+
+    private
+
+    def fields_to_update
+      { 'status-expa': status_to_podio(@application.status) }
+    end
+
+    def update_application_locally
+      @application.update_attribute(:podio_last_synched_status, @application.status)
+    end
+
+    def update_application_on_podio
+      RepositoryPodio.update_fields(@application.prep_podio_id, fields_to_update)
+    end
+
+    def status_to_podio(status)
+      translation = { approved: 1, realized: 2, finished: 3, completed: 4, realization_broken: 5, withdrawn: 6 }
+
+      translation[status.to_sym]
+    end
+  end
+end

--- a/db/migrate/20191025180322_add_podio_last_synched_status_to_expa_applications.rb
+++ b/db/migrate/20191025180322_add_podio_last_synched_status_to_expa_applications.rb
@@ -1,0 +1,5 @@
+class AddPodioLastSynchedStatusToExpaApplications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :expa_applications, :podio_last_synched_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_12_185140) do
+ActiveRecord::Schema.define(version: 2019_10_25_180322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -146,6 +146,7 @@ ActiveRecord::Schema.define(version: 2019_07_12_185140) do
     t.datetime "opportunity_start_date"
     t.boolean "resync", default: false
     t.boolean "finished", default: false
+    t.string "podio_last_synched_status"
     t.index ["home_lc_id"], name: "index_expa_applications_on_home_lc_id"
     t.index ["home_mc_id"], name: "index_expa_applications_on_home_mc_id"
     t.index ["host_lc_id"], name: "index_expa_applications_on_host_lc_id"


### PR DESCRIPTION
Now the :after_save Expa::Application hook now relies on two checks, firstly we check wether the application has been sent over to Podio or not
and send it over (if that's the case), then, secondly we check if there is any discrepancy between the last status sent to Podio and the current status (which may have been
changed due to incoming EXPA API data) and update it whenever needed (both on Podio and locally so we keep track of these).

Adds a generic Item update method in RepositoryPodio and supplies migration for the newly added field expa_applications.podio_last_synched_status