### PR TITLE
feat[BR-358](expa_people_to_podio): adds synchronization for incoming exchange participants from EXPA (persisted locally) to Podio

### DIFF
--- a/app/models/exchange_participant.rb
+++ b/app/models/exchange_participant.rb
@@ -28,6 +28,8 @@ class ExchangeParticipant < ApplicationRecord
 
   enum exchange_type: { ogx: 0, icx: 1}
 
+  enum origin: { databazi: 0, expa: 1 }
+
   enum status: { open: 1, applied: 2, accepted: 3, approved_tn_manager: 4, approved_ep_manager: 5, approved: 6,
     break_approved: 7, rejected: 8, withdrawn: 9,
     realized: 100, approval_broken: 101, realization_broken: 102, matched: 103,
@@ -80,6 +82,10 @@ class ExchangeParticipant < ApplicationRecord
 
   def last_name
     fullname.split(' ').drop(1).join(' ')
+  end
+
+  def local_committee_podio_id
+    local_committee.try(:podio_id)
   end
 
   def as_sqs

--- a/app/services/brazil/expa.rb
+++ b/app/services/brazil/expa.rb
@@ -1,0 +1,4 @@
+module Brazil
+  module Expa
+  end
+end

--- a/app/services/brazil/expa/people.rb
+++ b/app/services/brazil/expa/people.rb
@@ -1,0 +1,131 @@
+require "#{Rails.root}/lib/expa_api"
+
+module Brazil
+  module Expa
+    class People
+      def self.call
+        new.call
+      end
+
+      def call
+        load_expa_people(from) { |person| perform_on_exchange_participant(person) }
+      end
+
+      private
+
+      def expa_person_status(status)
+        status == 'other' ? 'other_status' : status
+      end
+
+      def from
+        (ExchangeParticipant
+          .where.not(updated_at_expa: nil)
+          .order(updated_at_expa: :desc)
+          .first&.updated_at_expa  || 1.days.ago) + 1
+      end
+
+      def load_expa_people(from, page = 1, &callback)
+        res = query_all_people(from)
+
+        total_pages = res&.data&.all_people&.paging&.total_pages
+
+        people = res&.data&.all_people&.data
+
+        # puts total_pages
+        # puts res&.data&.all_people&.paging&.total_items
+        # puts "Current page: #{page}"
+
+        people.each do |person|
+          begin
+            callback.call(person)
+          rescue => exception
+            Raven.extra_context exchange_participant_expa_id: person.id
+            Raven.capture_exception(exception)
+            logger = logger || Logger.new(STDOUT)
+            logger.error exception.message
+            logger.error(exception.backtrace.map { |s| "\n#{s}" })
+            break
+          end
+
+        end if people
+
+        people = nil
+
+        return load_expa_people(
+          from,
+          page + 1,
+          &callback
+        ) unless res.nil? || page + 1 > total_pages
+      end
+
+      def perform_on_exchange_participant(person)
+        exchange_participant = ExchangeParticipant.find_by(expa_id: person.id)
+
+        return if person.status == 'deleted'
+
+        unless exchange_participant
+          ExchangeParticipant.new(expa_id: person.id,
+                                  updated_at_expa: person.updated_at,
+                                  fullname: person.full_name,
+                                  email: person.email,
+                                  birthdate: person.dob,
+                                  local_committee: LocalCommittee.find_by(expa_id: person.try(:home_lc).try(:id)),
+                                  origin: :expa,
+                                  status: expa_person_status(person&.status)
+                                ).save(validate: false)
+        end
+
+        exchange_participant.update_attributes(updated_at_expa: person.updated_at) if exchange_participant
+
+        sleep 3
+      end
+
+      def query_all_people(from)
+        EXPAAPI::Client.query(
+          ALLPEOPLEOGX,
+          variables: {
+            from: from
+          }
+        )
+      end
+    end
+  end
+end
+
+ALLPEOPLEOGX = EXPAAPI::Client.parse <<~'GRAPHQL'
+  query ($from: DateTime) {
+    allPeople(per_page: 500, sort: "+updated_at",
+              filters: {
+                home_committee: 1606,
+                last_interaction: { from: $from }
+              }
+    ) {
+        paging {
+          total_pages
+          total_items
+        }
+        data {
+          id
+          full_name
+          email
+          status
+          dob
+
+          home_lc {
+            id
+            name
+            full_name
+          }
+
+          programmes {
+            id
+            short_name
+            short_name_display
+          }
+
+          updated_at
+        }
+    }
+  }
+GRAPHQL
+

--- a/app/services/brazil/expa_people_to_podio.rb
+++ b/app/services/brazil/expa_people_to_podio.rb
@@ -1,0 +1,67 @@
+module Brazil
+  class ExpaPeopleToPodio
+    attr_reader :status
+
+    def self.call
+      new.call
+    end
+
+    def initialize
+      @status = false
+    end
+
+    def call
+      pending_exchange_participants.each do |exchange_participant|
+        @status = Brazil::PodioOgxIntegrator.call(assemble_message(exchange_participant))
+
+        puts "@status = #{@status} for ep #{exchange_participant.fullname}"
+
+        exchange_participant.update_attribute(:has_error, true) unless @status
+
+        sleep 3
+      end
+    end
+
+    private
+
+    # based on given databazi_keys, assembles the message as `{ key => value }` based on given key existence (non-nil value) on exchange_participant
+    def assemble_message(exchange_participant)
+      message = { 'exchange_participant_id' => exchange_participant.id }
+      databazi_keys.each { |k| if value = exchange_participant.try(k.to_sym); message.store(trim_key(k), normalize_value(value)); end }
+
+      message
+    end
+
+    # list of (databazi) keys expected to be synchronized with podio
+    def databazi_keys
+      %w[
+        birthdate
+        cellphone
+        email
+        expa_id
+        fullname
+        local_committee_podio_id
+        status
+      ]
+    end
+
+    # key trimming method so we match the expected identifiers established in Brazil::PodioOgxIntegrator#optional_keys
+    # reserved keys, i.e. those not to be trimmed, goes into RESERVED_DATABAZI_IDENTIFIERS
+    def trim_key(key)
+      key.gsub(/_podio_id$/, '')
+    end
+
+    def normalize_value(value)
+      return value.to_s if (value.instance_of? Date)
+
+      value
+    end
+
+    def pending_exchange_participants
+      ExchangeParticipant.where(podio_id: nil)
+                         .where(origin: :expa)
+                         .order(created_at: :desc)
+                         .limit(10)
+    end
+  end
+end

--- a/app/services/brazil/podio_ogx_prep_integrator.rb
+++ b/app/services/brazil/podio_ogx_prep_integrator.rb
@@ -14,7 +14,7 @@ module Brazil
     def call
       podio_params = {}
 
-      podio_params.store('nome-do-ep', @application.exchange_participant.podio_id)
+      podio_params.store('nome-do-ep', @application.try(:exchange_participant).try(:podio_id)
 
       prep_keys.each { |k,v| @application.try(v[0].to_sym) ? podio_params.store(k.to_s, normalize_data(@application.send(v[0].to_sym), v[1])) : next }
 

--- a/app/services/brazil/podio_ogx_prep_integrator.rb
+++ b/app/services/brazil/podio_ogx_prep_integrator.rb
@@ -14,7 +14,7 @@ module Brazil
     def call
       podio_params = {}
 
-      podio_params.store('nome-do-ep', @application.try(:exchange_participant).try(:podio_id)
+      podio_params.store('nome-do-ep', @application.try(:exchange_participant).try(:podio_id))
 
       prep_keys.each { |k,v| @application.try(v[0].to_sym) ? podio_params.store(k.to_s, normalize_data(@application.send(v[0].to_sym), v[1])) : next }
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,14 @@
 set :output, path + "/cron_log.log"
 
 every 5.minutes do
+  runner "Brazil::ExpaPeopleToPodio.call", environment: 'production'
+end
+
+every 5.minutes do
+  runner "Brazil::Expa::People.call", environment: 'production'
+end
+
+every 5.minutes do
   runner "ExpaApplicationSync.call", environment: 'production'
 end
 

--- a/db/migrate/20191029135923_add_updated_at_expa_to_exchange_participants.rb
+++ b/db/migrate/20191029135923_add_updated_at_expa_to_exchange_participants.rb
@@ -1,0 +1,5 @@
+class AddUpdatedAtExpaToExchangeParticipants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :exchange_participants, :updated_at_expa, :datetime
+  end
+end

--- a/db/migrate/20191029174729_add_origin_to_exchange_participants.rb
+++ b/db/migrate/20191029174729_add_origin_to_exchange_participants.rb
@@ -1,0 +1,5 @@
+class AddOriginToExchangeParticipants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :exchange_participants, :origin, :integer, default: :databazi
+  end
+end

--- a/db/migrate/20191030025642_add_has_error_to_exchange_participant.rb
+++ b/db/migrate/20191030025642_add_has_error_to_exchange_participant.rb
@@ -1,0 +1,5 @@
+class AddHasErrorToExchangeParticipant < ActiveRecord::Migration[5.2]
+  def change
+    add_column :exchange_participants, :has_error, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_25_180322) do
+ActiveRecord::Schema.define(version: 2019_10_29_174729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,8 @@ ActiveRecord::Schema.define(version: 2019_10_25_180322) do
     t.text "academic_backgrounds", array: true
     t.integer "referral_type"
     t.datetime "deleted_at"
+    t.datetime "updated_at_expa"
+    t.integer "origin"
     t.index ["college_course_id"], name: "index_exchange_participants_on_college_course_id"
     t.index ["local_committee_id"], name: "index_exchange_participants_on_local_committee_id"
     t.index ["registerable_type", "registerable_id"], name: "registerable_index_on_exchange_participants"


### PR DESCRIPTION
On models/ExchangeParticipant adds enum denoting its origin and #local_committee_podio_id helper method
Slightly refactors services/brazil/podio_ogx_integrator as it needed a cleaner interface to also handle this newly added synchronization.

Adds services/brazil/expa/people, responsible for retrieving exchange participants from EXPA and saving it on our database.
The services/brazil/expa_people_to_podio file fetches synchronization pending exchanging participants and send them over to Podio

Adds new rules to schedule.rb and migrations for newly used fields.